### PR TITLE
On localhost:8000, redirect to `/blog` when visiting `/` route

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,0 +1,15 @@
+import React from "react";
+
+const HomePage = () => {
+  // if the user visits '/' route while working on the blog project (without main-website)
+  // then redirect the user to '/blog' route.
+  React.useEffect(() => {
+    window.location = "/blog";
+  }, []);
+
+  return (
+    <p style={{ textAlign: "center" }}>Redirecting...</p>
+  )
+}
+
+export default HomePage;


### PR DESCRIPTION
Issue: #8 

## Summary of problem
- When working on the blog project locally, if we visit `http://localhost:8000`, a default Gatsby development 404 page is displayed.
- This is annoying as the user has to manually redirect to `/blog`

## Summary of solution
- Add a page at the `http://localhost:8000` route which redirects the user to `http://localhost:8000/blog` route.

### Testing
- [x] Tested on the blog project as standalone ( http://localhost:8000 - redirected to `/blog` )
- [x] Tested on the `main-website` project
  - [x] http://localhost:9001 - shows the webflow home page as expected
  - [x] accessing the page by visiting `http://localhost:9001/blog/index.html` displays the correct page - `/blog` ( thanks to https://github.com/supertokens/supertokens-backend-website/pull/42 ).