### PR TITLE
Style updates for inline code snippets and blockquotes

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -185,6 +185,7 @@ ul li,
 ol li {
   padding-left: var(--gatsbySpacing-0);
   margin-bottom: calc(var(--gatsbySpacing-8) / 2);
+  line-height: var(--gatsbyLineHeight-relaxed);
 }
 
 li > p {
@@ -202,13 +203,13 @@ li > ul {
 
 blockquote {
   color: var(--gatsbyColor-text-light);
-  margin-left: 0px;
-  margin-right: var(--gatsbySpacing-8);
-  padding: var(--gatsbySpacing-0) var(--gatsbySpacing-0) var(--gatsbySpacing-0) var(--gatsbySpacing-4);
-  border-left: var(--gatsbySpacing-1) solid var(--gatsbyColor-primary);
+  background-color: rgba(255, 153, 51, .16);
+  border-radius: var(--gatsbySpacing-1);
+  border: 1px solid rgba(255, 153, 51, .3);
+  padding: var(--gatsbySpacing-3) var(--gatsbySpacing-4);
   font-size: var(--gatsbyFontSize-1);
   font-style: italic;
-  margin-bottom: var(--gatsbySpacing-8);
+  margin: 0px 0px var(--gatsbySpacing-8);
 }
 
 blockquote > :last-child {
@@ -338,18 +339,14 @@ a:focus {
 /* Media queries */
 
 @media (max-width: 42rem) {
-  blockquote {
-    padding: var(--gatsbySpacing-0) var(--gatsbySpacing-0) var(--gatsbySpacing-0) var(--gatsbySpacing-4);
-    margin-left: var(--gatsbySpacing-0);
-  }
   ul,
   ol {
     list-style-position: inside;
   }
 }
 
-:not(pre) > code.language-text {
-  word-break: break-all !important;
+:not(pre) > code.language-text, .footnote-list-item code {
+  word-break: break-word !important;
   background-color: #f2f2f2 !important;
   color: #d65078 !important;
   padding-left: 4px !important;


### PR DESCRIPTION
# Changes made

## Inline code snippets do not break at meaningful word positions
**Before**
<img width="668" alt="Screenshot 2022-03-02 at 4 17 56 PM" src="https://user-images.githubusercontent.com/92283713/156347422-6aecb86d-d4e3-4e8d-b872-2f7689ce944c.png">

**After**
<img width="501" alt="Screenshot 2022-03-02 at 4 18 41 PM" src="https://user-images.githubusercontent.com/92283713/156347525-42d1567e-e3dd-4d2f-9c70-d870e789a2ba.png">

## Inline code snippets are styled properly inside footnotes.
<img width="694" alt="Screenshot 2022-03-02 at 4 21 09 PM" src="https://user-images.githubusercontent.com/92283713/156347875-0e6d8450-1e3d-427c-8cc3-ccd24b342139.png">

## Updated blockquote style to match the current blog style
**Before**
<img width="617" alt="Screenshot 2022-03-02 at 4 22 49 PM" src="https://user-images.githubusercontent.com/92283713/156348115-ca9f84b9-e9a0-4334-bfaf-8a6215059e3e.png">

**After**
<img width="652" alt="Screenshot 2022-03-02 at 4 22 37 PM" src="https://user-images.githubusercontent.com/92283713/156348089-bf9c947c-71fc-496a-a891-e3880a1d38bf.png">

## Updated line-height for list items
**Before**
<img width="634" alt="Screenshot 2022-03-02 at 4 24 37 PM" src="https://user-images.githubusercontent.com/92283713/156348398-48d623bd-72cf-43c5-9126-462cafa400d3.png">

**After**
<img width="622" alt="Screenshot 2022-03-02 at 4 25 02 PM" src="https://user-images.githubusercontent.com/92283713/156348466-7104300e-2964-4490-80da-529183e40369.png">

