### PR TITLE
Adds a GitHub Action to check if yarn.lock file exists

### DIFF
--- a/.github/workflows/file_check.yml
+++ b/.github/workflows/file_check.yml
@@ -1,0 +1,19 @@
+name: File checks
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  yarn_lock_check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Check if yarn.lock exists
+      run: |
+        if [ -f yarn.lock ]
+        then
+        echo "yarn.lock exists."
+        exit 1
+        fi


### PR DESCRIPTION
### Issue: #14 

## Goal
- We want to check if a `yarn.lock` file is added when a PR is made.

## Solution
- Adds a GitHub Action which fails if a `yarn.lock` exists in the PR.
- You can see it failing [here](https://github.com/st-jay/blog/pull/5) as a `yarn.lock` file is present.
- You can see it passing [here](https://github.com/st-jay/blog/pull/6) as a `yarn.lock` file is not present.
