### PR TITLE
Fixes aspect ratio of cover images in the blog listing page and some minor changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ For any queries, or support requests, please email us at team@supertokens.com, o
 
 ## Authors
 
-Created with :heart: by the folks at supertokens.com.
+Created with :heart: by the folks at [SuperTokens](https://supertokens.com).

--- a/src/getBlogCardString.js
+++ b/src/getBlogCardString.js
@@ -2,11 +2,13 @@ module.exports = function (post) {
   try {
     const renderedPost = `
       <a href="${post.fields.slug ? `/blog${post.fields.slug}` : post.fields.url}" class="blog-card">
-        <img
-          src="${"/covers/" + post.frontmatter.cover}"
-          alt="Blog cover"
-          class="blog-card__image"
-        />
+        <div class="blog-card__image-container">
+          <img
+            src="${"/covers/" + post.frontmatter.cover}"
+            alt="Blog cover"
+            class="blog-card__image"
+          />
+        </div>
         <p class="blog-card__date">${post.frontmatter.date}</p>
         <p class="blog-card__title">${post.frontmatter.title}</p>
         <p class="blog-card__excerpt">${post.frontmatter.description || post.excerpt}</p>

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -18,6 +18,7 @@
 .blog-categories {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
 }
 
 .blog-categories__category {
@@ -28,7 +29,7 @@
   text-transform: uppercase;
   border-radius: 4px;
   color: #ff8000;
-  margin-bottom: 20px;
+  margin: 0px 10px 20px;
   cursor: pointer;
   transition: background-color .15s, color .15s;
 }
@@ -40,10 +41,6 @@
 
 .blog-categories__category:not(.selected):hover {
   background-color: rgba(255, 153, 51, .1);
-}
-
-.blog-categories__category:not(:last-of-type) {
-  margin-right: 20px;
 }
 
 /* home page blog card styles */
@@ -126,10 +123,10 @@
   }
 
   .blog-card {
-    margin: 0px auto 10px;
+    margin: 0px auto 20px;
   }
   
-  .blog-card__image {
+  .blog-card__image-container {
     width: 300px;
   }
 }

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -74,10 +74,19 @@
   color: var(--gatsbyColor-primary);
 }
 
-.blog-card__image {
+.blog-card__image-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
   width: 360px;
   height: 160px;
   border-radius: 4px;
+}
+
+.blog-card__image {
+  min-height: 100%;
+  width: 100%;
 }
 
 .blog-card__date {

--- a/src/templates/blog-home.js
+++ b/src/templates/blog-home.js
@@ -33,24 +33,28 @@ const BlogHomeTemplate = (props) => {
 
         <div className="blog-categories">
           <button
+            id="tab-1-id"
             className={`blog-categories__category ${selectedCategory === "all" && "selected"}`}
             onClick={() => updateCategory("all")}
-          >
+            >
             All
           </button>
           <button
+            id="tab-2-id"
             className={`blog-categories__category ${selectedCategory === "sessions" && "selected"}`}
             onClick={() => updateCategory("sessions")}
-          >
+            >
             Sessions
           </button>
           <button
+            id="tab-3-id"
             className={`blog-categories__category ${selectedCategory === "featured" && "selected"}`}
             onClick={() => updateCategory("featured")}
-          >
+            >
             Featured
           </button>
           <button
+            id="tab-4-id"
             className={`blog-categories__category ${selectedCategory === "programming" && "selected"}`}
             onClick={() => updateCategory("programming")}
           >


### PR DESCRIPTION
## Connected Issues
- Issue #18 

## Summary of goal
- Cover images in the blog cards on blog listing page should not appear stretched
- The tab buttons on the blog listing page should emit correct analytics events
- The tab buttons on the blog listing page should be aligned to centre on smaller screens

## Summary of changes
- Set the cover images to have a fixed width, and adjust the height according to the width. This way, the images having aspect ratio less than 2.25 will not appear stretched. Also set a `min-height` for the images that have an aspect ratio greater than the aspect ratio of the cover image element ( which is 2.25 ).
- Add the ids `tab-1-id`, `tab-2-id`, `tab-3-id`, `tab-4-id` to the `All`, `Sessions`, `Featured` and `Programming` tabs respectively. The ids already have events associated with them.
- Use left and right margin instead of only right margin for spacing of tab buttons on blog listing page and justify them to centre, so on smaller screens, they are aligned to centre.

### Remaining TODOs
- [ ] ~Remaining change...~

## Results
- ~Screenshots or links to videos~

## Testing
#### Tested on all primary browsers for:
- Chrome
  - [x] Desktop
  - [x] Mobile
  - [x] Tablet
- Safari
  - [x] Desktop
  - [x] Mobile
  - [x] Tablet
- Firefox
  - [x] Desktop
  - [x] Mobile
  - [x] Tablet
- (Optional) Tested on Safari 12 (Physical or emulator)
  - [x] iPad
  - [x] iPhone
- (Optional) Tested on physical mobile and tablet device for:
  - [ ] Android
  - [ ] iOS (including iPadOS)

#### Tested analytics events
- [X] All pre-existing events are working
- Newly added analytic events
  - [ ] ~description of when the event would occur~