### PR TITLE
Display all cover images with 1.9 aspect ratio

### DIFF
--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -72,18 +72,20 @@
 }
 
 .blog-card__image-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
   overflow: hidden;
   width: 360px;
-  height: 160px;
+  padding-top: 52.5%;
   border-radius: 4px;
+  position: relative;
 }
 
 .blog-card__image {
-  min-height: 100%;
   width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
 
 .blog-card__date {


### PR DESCRIPTION
## Connected Issues
- Issue #18 

## Summary of goal
Display all cover images in the blog listing page with a uniform aspect ratio

## Summary of solution
- Set the aspect ratio of the image to be 1.9 using the `padding-top` property on it's parent. The `padding-top` is set to `(1/<aspect-ratio>) * 100%` ( which is `52.5%` in this case ). 

### Remaining TODOs
- [ ] ~Remaining change...~

## Results
<img width="1056" alt="Screenshot 2022-03-07 at 11 35 25 AM" src="https://user-images.githubusercontent.com/92283713/156977255-30e1481f-2aac-4f1b-b449-2c3b0687a8a7.png">


## Testing
#### Tested on all primary browsers for:
- Chrome
  - [X] Desktop
  - [X] Mobile
  - [X] Tablet
- Safari
  - [X] Desktop
  - [X] Mobile
  - [X] Tablet
- Firefox
  - [X] Desktop
  - [X] Mobile
  - [X] Tablet
- (Optional) Tested on Safari 12 (Physical or emulator)
  - [X] iPad
  - [X] iPhone
- (Optional) Tested on physical mobile and tablet device for:
  - [ ] ~Android~
  - [ ] ~iOS (including iPadOS)~

#### Tested analytics events
- [ ] ~All pre-existing events are working~
- Newly added analytic events
  - [ ] ~description of when the event would occur~