### PR TITLE
display all cover images with 1.9 aspect ratio

### DIFF
--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -72,18 +72,20 @@
 }
 
 .blog-card__image-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
   overflow: hidden;
   width: 360px;
-  height: 160px;
+  padding-top: 52.5%;
   border-radius: 4px;
+  position: relative;
 }
 
 .blog-card__image {
-  min-height: 100%;
   width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
 }
 
 .blog-card__date {

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -74,7 +74,7 @@
 .blog-card__image-container {
   overflow: hidden;
   width: 360px;
-  height: calc(360px / 1.904); /* calculate the width using the aspect ratio 1.904 */
+  height: calc(360px / 1.9); /* calculate the width using the aspect ratio 1.9 */
   border-radius: 4px;
 }
 
@@ -126,7 +126,7 @@
   
   .blog-card__image-container {
     width: 300px;
-    height: calc(300px / 1.904); /* calculate the width using the aspect ratio 1.904 */
+    height: calc(300px / 1.9); /* calculate the width using the aspect ratio 1.9 */
   }
 }
 

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -74,18 +74,14 @@
 .blog-card__image-container {
   overflow: hidden;
   width: 360px;
-  padding-top: 52.5%;
+  height: 189px;
   border-radius: 4px;
-  position: relative;
 }
 
 .blog-card__image {
+  height: 100%;
   width: 100%;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  object-fit: cover;
 }
 
 .blog-card__date {
@@ -130,6 +126,7 @@
   
   .blog-card__image-container {
     width: 300px;
+    height: 158px;
   }
 }
 

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -126,7 +126,7 @@
   
   .blog-card__image-container {
     width: 300px;
-    height: 158px;
+    height: 157px;
   }
 }
 

--- a/src/styles/blog.css
+++ b/src/styles/blog.css
@@ -74,7 +74,7 @@
 .blog-card__image-container {
   overflow: hidden;
   width: 360px;
-  height: 189px;
+  height: calc(360px / 1.904); /* calculate the width using the aspect ratio 1.904 */
   border-radius: 4px;
 }
 
@@ -126,7 +126,7 @@
   
   .blog-card__image-container {
     width: 300px;
-    height: 157px;
+    height: calc(300px / 1.904); /* calculate the width using the aspect ratio 1.904 */
   }
 }
 


### PR DESCRIPTION
## Connected Issues
- Issue #18 

## Summary of goal
Display all cover images in the blog listing page with a uniform aspect ratio

## Summary of solution
- Use `object-fit: cover` for all images so that they resize to fill the container ( which has an aspect ratio 1.9 ) without stretching.

### Remaining TODOs
- [ ] ~Remaining change...~

## Results
<img width="1056" alt="Screenshot 2022-03-07 at 11 35 25 AM" src="https://user-images.githubusercontent.com/92283713/156977255-30e1481f-2aac-4f1b-b449-2c3b0687a8a7.png">


## Testing
#### Tested on all primary browsers for:
- Chrome
  - [X] Desktop
  - [X] Mobile
  - [X] Tablet
- Safari
  - [X] Desktop
  - [X] Mobile
  - [X] Tablet
- Firefox
  - [X] Desktop
  - [X] Mobile
  - [X] Tablet
- (Optional) Tested on Safari 12 (Physical or emulator)
  - [X] iPad
  - [X] iPhone
- (Optional) Tested on physical mobile and tablet device for:
  - [ ] ~Android~
  - [ ] ~iOS (including iPadOS)~

#### Tested analytics events
- [ ] ~All pre-existing events are working~
- Newly added analytic events
  - [ ] ~description of when the event would occur~