### PR TITLE
Add `rel="nofollow"` to external links used in blog

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -59,7 +59,7 @@ module.exports = {
           {
             resolve: "gatsby-remark-external-links",
             options: {
-              rel: "nofollow noopener"
+              rel: "nofollow"
             }
           },
           `gatsby-remark-code-titles`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -56,6 +56,12 @@ module.exports = {
               toasterText: "Copied!"
             }
           },
+          {
+            resolve: "gatsby-remark-external-links",
+            options: {
+              rel: "nofollow noopener"
+            }
+          },
           `gatsby-remark-code-titles`,
           `gatsby-remark-prismjs`,
           `gatsby-remark-copy-linked-files`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "gatsby-plugin-react-helmet": "^5.7.0",
         "gatsby-plugin-sharp": "^4.7.0",
         "gatsby-remark-copy-linked-files": "^5.7.0",
+        "gatsby-remark-external-links": "^0.0.4",
         "gatsby-remark-images": "^6.7.0",
         "gatsby-remark-prismjs": "^6.7.0",
         "gatsby-remark-responsive-iframe": "^5.7.0",
@@ -4033,6 +4034,27 @@
         "@babel/core": "^7.11.6",
         "core-js": "^3.0.0"
       }
+    },
+    "node_modules/babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dependencies": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "node_modules/babel-runtime/node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "hasInstallScript": true
+    },
+    "node_modules/babel-runtime/node_modules/regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "node_modules/backo2": {
       "version": "1.0.2",
@@ -8944,6 +8966,57 @@
         "gatsby": "^4.0.0-next"
       }
     },
+    "node_modules/gatsby-remark-external-links": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-external-links/-/gatsby-remark-external-links-0.0.4.tgz",
+      "integrity": "sha512-JIKZguAGoGlzsJusfCb4JKM5E6JUEDbtlBkbErt7CdMnfBP+AldZeMQEQWK5xsJ5uXCyc4qqcBWR8vp0afFpOw==",
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "is-relative-url": "^2.0.0",
+        "unist-util-find": "^1.0.1",
+        "unist-util-visit": "^1.1.3"
+      }
+    },
+    "node_modules/gatsby-remark-external-links/node_modules/is-absolute-url": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+      "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gatsby-remark-external-links/node_modules/is-relative-url": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-2.0.0.tgz",
+      "integrity": "sha1-cpAtf+BLPUeS59sV+duEtyBMnO8=",
+      "dependencies": {
+        "is-absolute-url": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gatsby-remark-external-links/node_modules/unist-util-is": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+    },
+    "node_modules/gatsby-remark-external-links/node_modules/unist-util-visit": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "dependencies": {
+        "unist-util-visit-parents": "^2.0.0"
+      }
+    },
+    "node_modules/gatsby-remark-external-links/node_modules/unist-util-visit-parents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "dependencies": {
+        "unist-util-is": "^3.0.0"
+      }
+    },
     "node_modules/gatsby-remark-images": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-6.9.0.tgz",
@@ -11851,6 +11924,11 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
       "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+    },
+    "node_modules/lodash.iteratee": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.iteratee/-/lodash.iteratee-4.7.0.tgz",
+      "integrity": "sha1-vkF32yiajMw8CZDx2ya1si/BVUw="
     },
     "node_modules/lodash.kebabcase": {
       "version": "4.1.1",
@@ -18194,6 +18272,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/unist-util-find": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-find/-/unist-util-find-1.0.2.tgz",
+      "integrity": "sha512-ft06UDYzqi9o9RmGP0sZWI/zvLLQiBW2/MD+rW6mDqbOWDcmknGX9orQPspfuGRYWr8eSJAmfsBcvOpfGRJseA==",
+      "dependencies": {
+        "lodash.iteratee": "^4.5.0",
+        "unist-util-visit": "^1.1.0"
+      }
+    },
+    "node_modules/unist-util-find/node_modules/unist-util-is": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+      "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+    },
+    "node_modules/unist-util-find/node_modules/unist-util-visit": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "dependencies": {
+        "unist-util-visit-parents": "^2.0.0"
+      }
+    },
+    "node_modules/unist-util-find/node_modules/unist-util-visit-parents": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "dependencies": {
+        "unist-util-is": "^3.0.0"
+      }
+    },
     "node_modules/unist-util-generated": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.6.tgz",
@@ -22488,6 +22596,27 @@
         "gatsby-legacy-polyfills": "^2.9.0"
       }
     },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.6.12",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+          "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
@@ -26299,6 +26428,53 @@
         "unist-util-visit": "^2.0.3"
       }
     },
+    "gatsby-remark-external-links": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-external-links/-/gatsby-remark-external-links-0.0.4.tgz",
+      "integrity": "sha512-JIKZguAGoGlzsJusfCb4JKM5E6JUEDbtlBkbErt7CdMnfBP+AldZeMQEQWK5xsJ5uXCyc4qqcBWR8vp0afFpOw==",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "is-relative-url": "^2.0.0",
+        "unist-util-find": "^1.0.1",
+        "unist-util-visit": "^1.1.3"
+      },
+      "dependencies": {
+        "is-absolute-url": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+          "integrity": "sha1-UFMN+4T8yap9vnhS6Do3uTufKqY="
+        },
+        "is-relative-url": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-2.0.0.tgz",
+          "integrity": "sha1-cpAtf+BLPUeS59sV+duEtyBMnO8=",
+          "requires": {
+            "is-absolute-url": "^2.0.0"
+          }
+        },
+        "unist-util-is": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+        },
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
+      }
+    },
     "gatsby-remark-images": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-6.9.0.tgz",
@@ -28358,6 +28534,11 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
       "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+    },
+    "lodash.iteratee": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.iteratee/-/lodash.iteratee-4.7.0.tgz",
+      "integrity": "sha1-vkF32yiajMw8CZDx2ya1si/BVUw="
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
@@ -33037,6 +33218,38 @@
       "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
       "requires": {
         "crypto-random-string": "^2.0.0"
+      }
+    },
+    "unist-util-find": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-find/-/unist-util-find-1.0.2.tgz",
+      "integrity": "sha512-ft06UDYzqi9o9RmGP0sZWI/zvLLQiBW2/MD+rW6mDqbOWDcmknGX9orQPspfuGRYWr8eSJAmfsBcvOpfGRJseA==",
+      "requires": {
+        "lodash.iteratee": "^4.5.0",
+        "unist-util-visit": "^1.1.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
+          "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+        },
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
       }
     },
     "unist-util-generated": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "gatsby-plugin-react-helmet": "^5.7.0",
     "gatsby-plugin-sharp": "^4.7.0",
     "gatsby-remark-copy-linked-files": "^5.7.0",
+    "gatsby-remark-external-links": "^0.0.4",
     "gatsby-remark-images": "^6.7.0",
     "gatsby-remark-prismjs": "^6.7.0",
     "gatsby-remark-responsive-iframe": "^5.7.0",

--- a/src/blog-details.js
+++ b/src/blog-details.js
@@ -86,6 +86,7 @@ module.exports = [
   {
     fields: {
       url: "https://www.youtube.com/watch?v=6Vzit514kZY&list=PLE5w09cAseKTIFCImkqFbSeYMHPzW7M_f&index=17",
+      nofollow: true
     },
     frontmatter: {
       title: "Detecting session hijacking using rotating refresh tokens - OSW 2020",

--- a/src/getBlogCardString.js
+++ b/src/getBlogCardString.js
@@ -6,9 +6,14 @@ module.exports = function (post) {
     href = href.substring(0, href.length - 1);
   }
 
+  let nofollowAttribute = "";
+  if (post.fields.nofollow) {
+    nofollowAttribute = "rel=\"nofollow\" target=\"_blank\"";
+  }
+
   try {
     const renderedPost = `
-      <a href="${href}" class="blog-card">
+      <a href="${href}" ${nofollowAttribute} class="blog-card">
         <div class="blog-card__image-container">
           <img
             src="${"/covers/" + post.frontmatter.cover}"

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -28,6 +28,15 @@ const BlogPostTemplate = ({ data, location }) => {
       $(backref).text(" ^");
     });
 
+    // removes rel="nofollow noreferrer" and target="_blank"
+    // from links having domain `https://supertokens.com`
+    $("a").each((_, a) => {
+      if ($(a).attr("href").startsWith("https://supertokens.com")) {
+        $(a).removeAttr("rel");
+        $(a).removeAttr("target");
+      }
+    });
+
     return $.html();
   }
 


### PR DESCRIPTION
## Connected Issues
- Issue #43 

## Summary of goal
All the external links on our blog should have `rel="nofollow" target="_blank"` attributes

## Summary of changes

### Feature updates
#### FOR BLOG LANDING PAGE
- Update the `src/getBlogCardString.js` file to add `rel="nofollow" target="_blank"` to cards that have a `nofollow: true` in their `fields`.

#### FOR BLOG POSTS
- Use the `gatsby-remark-external-links` plugin to automatically add `rel="nofollow" target="_blank"` attributes to external links.
- In `src/templates/blog-post.js` file, add a snippet to remove the added `rel="nofollow" target="_blank"` attributes from links that have `https://supertokens.com` as their domain.
- The `gatsby-remark-external-links` plugin adds `rel="nofollow" target="_blank"` attributes to all the links that are absolute ( i.e. have a domain specified in them ).


### Bug fixes
No bugs fixed.

### Remaining TODOs
- [x] Verify links on all posts and check if they have correct attributes

## Results
- ~Screenshots or links to videos~

## Testing
#### Tested on all primary browsers for:
- Chrome
  - [x] Desktop
  - [ ] ~Mobile~
  - [ ] ~Tablet~
- Safari
  - [ ] ~Desktop~
  - [ ] ~Mobile~
  - [ ] ~Tablet~
- Firefox
  - [ ] ~Desktop~
  - [ ] ~Mobile~
  - [ ] ~Tablet~
- (Optional) Tested on Safari 12 (Physical or emulator)
  - [ ] ~iPad~
  - [ ] ~iPhone~
- (Optional) Tested on physical mobile and tablet device for:
  - [ ] ~Android~
  - [ ] ~iOS (including iPadOS)~

#### Tested analytics events
- [ ] ~All pre-existing events are working~
- Newly added analytic events
  - [ ] ~description of when the event would occur~