### PR TITLE
Inherit inline code snippet font size from it's parent

### DIFF
--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -367,7 +367,7 @@ a:focus {
   color: #d65078 !important;
   padding-left: 4px !important;
   padding-right: 4px !important;
-  font-size: 16px !important;
+  font-size: inherit !important;
   border: 1px solid #d9d9d9 !important;
   white-space: pre-wrap !important;
   border-radius: 3px;


### PR DESCRIPTION
# Related Issue
#67 

## Summary of goal
- The font size of inline code snippets should match it's parent element

## Summary of solution
- Add the `font-size: inherit` style to inline code snippets instead of adding fix font size of `16px`

## Summary of changes
### Feature updates
No new feature added

### Bug fixes
- Fixed the bug where font size of inline code snippet in a heading was not of correct font size.

### Remaining TODOs
- [x] Design review

## Results
- https://user-images.githubusercontent.com/92283713/163755482-dd3a718c-fb4e-4720-92ad-a76b96dc9a8d.png


## Testing
#### Tested on all primary browsers for:
- Chrome
  - [x] Desktop
  - [x] Mobile
  - [x] Tablet
- Safari
  - [x] Desktop
  - [x] Mobile
  - [x] Tablet
- Firefox
  - [x] Desktop
  - [x] Mobile
  - [x] Tablet
- (Optional) Tested on Safari 12 (Physical or emulator)
  - [ ] iPad
  - [ ] iPhone
- (Optional) Tested on physical mobile and tablet device for:
  - [ ] Android
  - [ ] iOS (including iPadOS)

#### Tested analytics events
- [ ] ~All pre-existing events are working~
- Newly added analytic events
  - [ ] ~description of when the event would occur~