### PR TITLE
Updated `h4` font size to be different than `h3` and spacing updates for both

### DIFF
--- a/content/how-to-deploy-supertokens-with-react-nodejs-express-on-vercel/index.md
+++ b/content/how-to-deploy-supertokens-with-react-nodejs-express-on-vercel/index.md
@@ -11,10 +11,6 @@ In this tutorial, you’ll learn how to add SuperTokens authentication to your R
 
 ## Getting started
 
-### Heading 3
-
-#### Heading 4
-
 To get started with SuperTokens, please visit the [Recipe Guides page](https://supertokens.com/docs/guides) and pick the login method you want for your application. After choosing a guide, follow the quick setup section or one of the sections for integrating with a framework that you have chosen.
 
 We also have a blog post for how to integrate [email password + social login with express and react](https://supertokens.com/blog/how-to-set-up-social-and-email-password-login-with-reactjs), if that is what you are looking for.

--- a/content/how-to-deploy-supertokens-with-react-nodejs-express-on-vercel/index.md
+++ b/content/how-to-deploy-supertokens-with-react-nodejs-express-on-vercel/index.md
@@ -11,6 +11,10 @@ In this tutorial, you’ll learn how to add SuperTokens authentication to your R
 
 ## Getting started
 
+### Heading 3
+
+#### Heading 4
+
 To get started with SuperTokens, please visit the [Recipe Guides page](https://supertokens.com/docs/guides) and pick the login method you want for your application. After choosing a guide, follow the quick setup section or one of the sections for integrating with a framework that you have chosen.
 
 We also have a blog post for how to integrate [email password + social login with express and react](https://supertokens.com/blog/how-to-set-up-social-and-email-password-login-with-reactjs), if that is what you are looking for.

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -144,8 +144,11 @@ h3 {
 }
 
 h4 {
-  font-size: 1.5625rem;
+  font-size: 1.3125rem;
+  margin-top: 1.75rem;
   line-height: 2.125rem;
+  margin-bottom: 0rem;
+  padding-bottom: 1rem;
 }
 
 h5 {

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -53,6 +53,7 @@
   --gatsbyFontSize-1: 1rem;
   --gatsbyFontSize-2: 1.2rem;
   --gatsbyFontSize-3: 1.44rem;
+  --gatsbyFontSize-21px: 1.3125rem;
   --gatsbyFontSize-25px: 1.5625rem;
   --gatsbyFontSize-4: 1.728rem;
   --gatsbyFontSize-32px: 2rem;
@@ -143,7 +144,7 @@ h3 {
 }
 
 h4 {
-  font-size: 1.3125rem;
+  font-size: var(--gatsbyFontSize-21px);
   margin-top: 1.75rem;
   line-height: 2.125rem;
   margin-bottom: 0rem;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -137,10 +137,9 @@ h2 {
 
 h3 {
   font-size: var(--gatsbyFontSize-25px);
-  padding-bottom: var(--gatsbySpacing-4);
+  margin-bottom: var(--gatsbySpacing-4);
   line-height: 2.1875rem;
   margin-top: 2rem;
-  margin-bottom: 0rem;
 }
 
 h4 {


### PR DESCRIPTION
## Connected Issues
- Issue #82 

## Summary of goal
`h3` and `h4` should have different font sizes. Currently they both render at `25px` font size.

## Summary of solution
Update the font size and spacing styles for `h4`.

## Summary of changes
Style updates for `h4`
```css
font-size: 21px;
margin-top: 28px;
padding-bottom: 16px;
margin-bottom: 0px;
```

Style updates for `h3`
```diff
- padding-bottom: 16px;
+ margin-bottom: 16px;
```

### Feature updates
No new feature added

### Bug fixes
No bugs fixed

### Remaining TODOs
- [x] Design review

## Testing
#### Tested on all primary browsers for:
- Chrome
  - [x] Desktop
  - [x] Mobile
  - [x] Tablet
- Safari
  - [x] Desktop
  - [x] Mobile
  - [x] Tablet
- Firefox
  - [x] Desktop
  - [x] Mobile
  - [x] Tablet
- (Optional) Tested on Safari 12 (Physical or emulator)
  - [ ] ~iPad~
  - [ ] ~iPhone~
- (Optional) Tested on physical mobile and tablet device for:
  - [ ] ~Android~
  - [ ] ~iOS (including iPadOS)~

#### Tested analytics events
- [ ] ~All pre-existing events are working~
- Newly added analytic events
  - [ ] ~description of when the event would occur~