### PR TITLE
add loading lazy to blog card images after the first 3 cards

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -63,8 +63,9 @@ exports.createPages = async ({ actions, graphql }) => {
       }
 
       return post.frontmatter.category === filter || post.frontmatter.category.includes(filter);
-    }).map((post) => {
-      return getBlogCardString(post);
+    }).map((post, index) => {
+      // add `loading="lazy"` to blog cards after the first 3 cards
+      return getBlogCardString(post, index >= 3);
     }).join("");
   });
 

--- a/src/getBlogCardString.js
+++ b/src/getBlogCardString.js
@@ -1,4 +1,4 @@
-module.exports = function (post) {
+module.exports = function (post, addLazyLoadingToImage) {
   // if the url or slug of the post has a trailing '/'
   // we remove it
   let href = post.fields.slug ? `/blog${post.fields.slug}` : post.fields.url;
@@ -16,6 +16,7 @@ module.exports = function (post) {
       <a href="${href}" ${nofollowAttribute} class="blog-card">
         <div class="blog-card__image-container">
           <img
+            ${addLazyLoadingToImage ? "loading=\"lazy\"" : ""}
             src="${"/card_covers/" + post.frontmatter.cover}"
             alt="Blog cover"
             class="blog-card__image"


### PR DESCRIPTION
## Related issue:
- #93 

## Summary of changes
- add `loading="lazy"` to all blog listing page card images except the first 3 images