### PR TITLE
fix: Add anchor to the blog post's headers

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -62,6 +62,12 @@ module.exports = {
               rel: "nofollow"
             }
           },
+          {
+            resolve: `gatsby-remark-autolink-headers`,
+            options: {
+              elements: [`h2`, 'h3'],
+            },
+          },
           `gatsby-remark-code-titles`,
           `gatsby-remark-prismjs`,
           `gatsby-remark-copy-linked-files`,

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -62,12 +62,7 @@ module.exports = {
               rel: "nofollow"
             }
           },
-          {
-            resolve: `gatsby-remark-autolink-headers`,
-            options: {
-              elements: [`h2`, 'h3'],
-            },
-          },
+          `gatsby-remark-autolink-headers`,
           `gatsby-remark-code-titles`,
           `gatsby-remark-prismjs`,
           `gatsby-remark-copy-linked-files`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "gatsby-plugin-image": "^2.7.0",
         "gatsby-plugin-react-helmet": "^5.7.0",
         "gatsby-plugin-sharp": "^4.7.0",
+        "gatsby-remark-autolink-headers": "^5.22.0",
         "gatsby-remark-copy-linked-files": "^5.7.0",
         "gatsby-remark-external-links": "^0.0.4",
         "gatsby-remark-images": "^6.7.0",
@@ -8916,6 +8917,26 @@
         "@gatsbyjs/reach-router": "^1.3.5",
         "react": "^16.9.0 || ^17.0.0",
         "react-dom": "^16.9.0 || ^17.0.0"
+      }
+    },
+    "node_modules/gatsby-remark-autolink-headers": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-5.22.0.tgz",
+      "integrity": "sha512-Eyom72XpN2x2BLCKdgWYnseeqXIcN9kVZmaXECGzc/IrE6RBHTMjzCMZJx9Ii39OAOhILaumOEfYhnAIw6SWXg==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "github-slugger": "^1.3.0",
+        "lodash": "^4.17.21",
+        "mdast-util-to-string": "^2.0.0",
+        "unist-util-visit": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "peerDependencies": {
+        "gatsby": "^4.0.0-next",
+        "react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/gatsby-remark-code-buttons": {
@@ -26406,6 +26427,18 @@
       "requires": {
         "@babel/runtime": "^7.15.4",
         "prop-types": "^15.7.2"
+      }
+    },
+    "gatsby-remark-autolink-headers": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-5.22.0.tgz",
+      "integrity": "sha512-Eyom72XpN2x2BLCKdgWYnseeqXIcN9kVZmaXECGzc/IrE6RBHTMjzCMZJx9Ii39OAOhILaumOEfYhnAIw6SWXg==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "github-slugger": "^1.3.0",
+        "lodash": "^4.17.21",
+        "mdast-util-to-string": "^2.0.0",
+        "unist-util-visit": "^2.0.3"
       }
     },
     "gatsby-remark-code-buttons": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gatsby-plugin-image": "^2.7.0",
     "gatsby-plugin-react-helmet": "^5.7.0",
     "gatsby-plugin-sharp": "^4.7.0",
+    "gatsby-remark-autolink-headers": "^5.22.0",
     "gatsby-remark-copy-linked-files": "^5.7.0",
     "gatsby-remark-external-links": "^0.0.4",
     "gatsby-remark-images": "^6.7.0",


### PR DESCRIPTION
# Related Issue

- https://github.com/supertokens/blog/issues/5 good-to-have no.2

- anchor is only generated from markdown's headers.
- No anchor for `h1` of the page's title

The cursor position in the below GIF is just not accurate
![header anchor](https://user-images.githubusercontent.com/13642906/187909450-de2c5a89-d9bb-49a6-9f25-3929d8f1da21.gif)

# Link to Google Doc
NA

# Checklist
- [ ] Has cover image been added
- [ ] Have all content images been added. Do they render correctly? (aspect ratio etc)
- [ ] The code inside code blocks gives no errors
- [ ] Check for SEO keyword?
- [ ] Added call to action to link to supertokens and to link to other blogs.
- [ ] Add reference to how SuperTokens solves this blog's problem (if relevant).

# Remaining TODOs
NA